### PR TITLE
Hotfix: only retrieve subject text.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Teamwork Note",
-  "version": "1.1",
+  "version": "1.1.1",
   "description": "Help you fetch a note from Teamwork single ticket view",
   "icons": {
     "64": "icons/icon-64.png"

--- a/popup/content-script/content-script.js
+++ b/popup/content-script/content-script.js
@@ -24,7 +24,7 @@
 
       var ticketId = document.getElementsByClassName("ticket-id")[0].innerHTML;
       var ticketCustomerFullname = document.getElementsByClassName("customer-fullname")[0].innerHTML;
-      var ticketSubject = document.getElementsByClassName("title__subject")[0].innerHTML;
+      var ticketSubject = document.getElementsByClassName("title__subject-text")[0].textContent;
 
       var data = {
         ticketId: ticketId.trim(),


### PR DESCRIPTION
Fixed an issue where it's fetching more than just the subject text